### PR TITLE
Remove wrong info from footer

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -7,7 +7,7 @@ description: Snap! Wiki Home
 <section id="intro" class="row p-4 intro-heading text-left"> <div class="col-12 col-md-6 py-4 px-3 px-md-4 d-flex flex-column justify-content-center" id="intro-info"> <h1 class="display-4 m-0 mb-3 p-0 text-left">Unofficial Wiki For Snap<em>!</em></h1> <p class="lead mb-4">The Snap<em>!</em> Wiki is an unofficial wiki about Snap<em>!</em>, the programming language.</p>  </div> <div class="col-12 col-md-6" id="intro-img">  </div> </section>
 		<div class="credits"></p>
 <div id="footer">
-    <p>This site is under development. This wiki could not exist without Snap<i>!</i> and our favicon is from Snap<i>!</i>, too.</p>
+    <p>This site is under development. This wiki could not exist without Snap<i>!</i>.</p>
 </div>
 
 </html>


### PR DESCRIPTION
We no longer use Snap!'s favicon.