### PR TITLE
Remove statement saying that the wiki can be visited now

### DIFF
--- a/site/status.html
+++ b/site/status.html
@@ -10,7 +10,6 @@ title: Status
     invisible comment in the Wiki News section. You can read about it
     <a href="https://phabricator.miraheze.org/T6301">here</a>. Miraheze has
     upgraded to MediaWiki 1.35 on 28 October. There was also a scheduled
-    database maintanence on 14 October. You can visit the
-    <a href="https://snapwiki.miraheze.org/">wiki</a> now.
+    database maintanence on 14 October.
   </p>
 </div>


### PR DESCRIPTION
There is the Visit the Wiki button in the header to serve this purpose.