### PR TITLE
Replace "2020" with "2020-2021" in copyright disclaimer

### DIFF
--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -9,7 +9,7 @@
 <footer class="footer">
   <div class="container">
     <section>
-      <p>© 2020 Snap<em>!</em> Wiki contributors</p>
+      <p>© 2020-2021 Snap<em>!</em> Wiki contributors</p>
       <p>
         Snap<em>!</em> is licensed under the terms of GNU General Public License
         v3.0.


### PR DESCRIPTION
It is 2021 now.