### PR TITLE
Remove "Send Feedback" item from the navigation bar

### DIFF
--- a/site/_includes/nav.html
+++ b/site/_includes/nav.html
@@ -21,9 +21,6 @@
           <a class="nav-link" href="/status">Status</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/feedback">Send Feedback</a>
-        </li>
-        <li class="nav-item">
           <a
             class="nav-link"
             href="https://github.com/snapwiki/"


### PR DESCRIPTION
We do not really have a page for that. Why was that even added?