### PR TITLE
Replaece "Repository" with "Organization"

### DIFF
--- a/site/_includes/nav.html
+++ b/site/_includes/nav.html
@@ -26,7 +26,7 @@
             href="https://github.com/snapwiki/"
             aria-label="Organization on GitHub"
             rel="noopener"
-            >Repository
+            >Organization
             <svg
               xmlns="http://www.w3.org/2000/svg"
               xmlns:xlink="http://www.w3.org/1999/xlink"


### PR DESCRIPTION
The link leads to the org, not any repo.