### PR TITLE
Revert "Add HTTP header to opt out of FLoC"

### DIFF
--- a/site/assets/js/base.js
+++ b/site/assets/js/base.js
@@ -72,8 +72,3 @@ waitForElement("#dark-toggle").then(() => {
     }
   });
 });
-
-headers = new Headers();
-
-// Add HTTP header to opt out of Federated Learning of Cohorts (FLoC)
-headers.set("Permissions-Policy", "interest-cohort=()");


### PR DESCRIPTION
Reverts snapwiki/snapwiki.github.io#25. GH is now taking care of this.